### PR TITLE
Mejorar salida de netinfotool: datos estructurados, formato JSON/text y opciones CLI

### DIFF
--- a/src/netinfotool.py
+++ b/src/netinfotool.py
@@ -1,79 +1,198 @@
+import argparse
+import json
 import socket
-import requests
+from datetime import datetime
+from typing import Any, Dict, List, Optional
+
 import psutil
+import requests
 
 
-def obtener_informacion_host():
+def obtener_ip_externa(timeout: float = 3.0) -> Optional[str]:
     try:
-        hostname = socket.gethostname()
-        ip_addresses = socket.gethostbyname_ex(hostname)[2]
-
-        print(f"Hostname: {hostname}")
-        print("Direcciones IP asociadas:")
-        for ip in ip_addresses:
-            print(f"  - {ip}")
-
-        # Obtener dirección IP externa
-        try:
-            external_ip = requests.get("https://api.ipify.org").text
-            print(f"Dirección IP externa: {external_ip}")
-        except requests.RequestException:
-            print("Error: No se pudo obtener la dirección IP externa.")
-
-        # Mostrar información detallada de la red
-        print("\nInformación detallada de las interfaces de red:")
-        for interface, addrs in psutil.net_if_addrs().items():
-            print(f"\nInterfaz: {interface}")
-            for addr in addrs:
-                if addr.family == socket.AF_INET:
-                    print(f"  - Dirección IP: {addr.address}")
-                elif addr.family == socket.AF_INET6:
-                    print(f"  - Dirección IPv6: {addr.address}")
-                elif addr.family == psutil.AF_LINK:
-                    print(f"  - MAC: {addr.address}")
-
-    except socket.gaierror:
-        print("Error: No se pudo obtener la información del host.")
-    except Exception as e:
-        print(f"Error inesperado: {e}")
+        return requests.get("https://api.ipify.org", timeout=timeout).text
+    except requests.RequestException:
+        return None
 
 
-def guardar_informacion_en_archivo():
-    import datetime
-
-    filename = (
-        f"informacion_host_{datetime.datetime.now().strftime('%Y%m%d_%H%M%S')}.txt"
+def obtener_informacion_host(
+    incluir_ip_externa: bool = True, timeout_ip_externa: float = 3.0
+) -> Dict[str, Any]:
+    hostname = socket.gethostname()
+    ip_addresses = socket.gethostbyname_ex(hostname)[2]
+    external_ip = (
+        obtener_ip_externa(timeout=timeout_ip_externa)
+        if incluir_ip_externa
+        else None
     )
-    with open(filename, "w") as file:
-        # Redirigir salida estándar a archivo
-        import sys
+    interfaces: List[Dict[str, Any]] = []
+    stats = psutil.net_if_stats()
 
-        original_stdout = sys.stdout
-        sys.stdout = file
-        try:
-            obtener_informacion_host()
-        finally:
-            # Restaurar salida estándar y cerrar el archivo
-            sys.stdout = original_stdout
+    for interface, addrs in psutil.net_if_addrs().items():
+        ipv4 = []
+        ipv6 = []
+        mac = None
+        for addr in addrs:
+            if addr.family == socket.AF_INET:
+                ipv4.append(addr.address)
+            elif addr.family == socket.AF_INET6:
+                ipv6.append(addr.address)
+            elif addr.family == psutil.AF_LINK:
+                mac = addr.address
+        interface_stats = stats.get(interface)
+        interfaces.append(
+            {
+                "nombre": interface,
+                "ipv4": ipv4,
+                "ipv6": ipv6,
+                "mac": mac,
+                "estado": {
+                    "activo": interface_stats.isup if interface_stats else None,
+                    "velocidad_mbps": interface_stats.speed if interface_stats else None,
+                    "mtu": interface_stats.mtu if interface_stats else None,
+                    "duplex": getattr(interface_stats, "duplex", None)
+                    if interface_stats
+                    else None,
+                },
+            }
+        )
+
+    return {
+        "hostname": hostname,
+        "ip_locales": ip_addresses,
+        "ip_externa": external_ip,
+        "interfaces": interfaces,
+        "hora_consulta": datetime.now().isoformat(timespec="seconds"),
+    }
+
+
+def formatear_informacion_texto(info: Dict[str, Any]) -> str:
+    lineas = [f"Hostname: {info['hostname']}"]
+    lineas.append("Direcciones IP asociadas:")
+    for ip in info["ip_locales"]:
+        lineas.append(f"  - {ip}")
+    if info["ip_externa"]:
+        lineas.append(f"Dirección IP externa: {info['ip_externa']}")
+    else:
+        lineas.append("Dirección IP externa: No disponible.")
+
+    lineas.append("\nInformación detallada de las interfaces de red:")
+    for interface in info["interfaces"]:
+        lineas.append(f"\nInterfaz: {interface['nombre']}")
+        for ip in interface["ipv4"]:
+            lineas.append(f"  - Dirección IP: {ip}")
+        for ip in interface["ipv6"]:
+            lineas.append(f"  - Dirección IPv6: {ip}")
+        if interface["mac"]:
+            lineas.append(f"  - MAC: {interface['mac']}")
+        estado = interface["estado"]
+        if estado:
+            lineas.append("  - Estado:")
+            for clave, valor in estado.items():
+                lineas.append(f"    * {clave}: {valor}")
+    lineas.append(f"\nHora de consulta: {info['hora_consulta']}")
+    return "\n".join(lineas)
+
+
+def guardar_informacion_en_archivo(
+    info: Dict[str, Any], filename: Optional[str] = None, formato: str = "text"
+) -> str:
+    if not filename:
+        timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+        extension = "json" if formato == "json" else "txt"
+        filename = f"informacion_host_{timestamp}.{extension}"
+
+    if formato == "json":
+        contenido = json.dumps(info, indent=2, ensure_ascii=False)
+    else:
+        contenido = formatear_informacion_texto(info)
+
+    with open(filename, "w", encoding="utf-8") as file:
+        file.write(contenido)
+    return filename
+
+
+def mostrar_informacion(info: Dict[str, Any], formato: str = "text") -> None:
+    if formato == "json":
+        print(json.dumps(info, indent=2, ensure_ascii=False))
+    else:
+        print(formatear_informacion_texto(info))
 
 
 def menu():
     while True:
         print("\n--- Menú ---")
         print("1. Mostrar información del host")
-        print("2. Guardar información en archivo")
-        print("3. Salir")
+        print("2. Guardar información en archivo (texto)")
+        print("3. Guardar información en archivo (JSON)")
+        print("4. Salir")
         opcion = input("Seleccione una opción: ")
 
+        if opcion in {"1", "2", "3"}:
+            info = obtener_informacion_host()
         if opcion == "1":
-            obtener_informacion_host()
+            mostrar_informacion(info)
         elif opcion == "2":
-            guardar_informacion_en_archivo()
+            nombre = guardar_informacion_en_archivo(info, formato="text")
+            print(f"Información guardada en {nombre}")
         elif opcion == "3":
+            nombre = guardar_informacion_en_archivo(info, formato="json")
+            print(f"Información guardada en {nombre}")
+        elif opcion == "4":
             break
         else:
             print("Opción no válida. Por favor, intente de nuevo.")
 
 
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Herramienta para obtener información de red y del host."
+    )
+    parser.add_argument(
+        "--formato",
+        choices=("text", "json"),
+        default="text",
+        help="Formato de salida para mostrar o guardar.",
+    )
+    parser.add_argument(
+        "--guardar",
+        nargs="?",
+        const="",
+        help="Guardar la información en un archivo (opcionalmente indique el nombre).",
+    )
+    parser.add_argument(
+        "--sin-ip-externa",
+        action="store_true",
+        help="No consultar la IP externa.",
+    )
+    parser.add_argument(
+        "--timeout-ip-externa",
+        type=float,
+        default=3.0,
+        help="Tiempo de espera para consultar la IP externa.",
+    )
+    parser.add_argument(
+        "--menu",
+        action="store_true",
+        help="Mostrar menú interactivo.",
+    )
+    return parser.parse_args()
+
+
 if __name__ == "__main__":
-    menu()
+    args = parse_args()
+    if args.menu:
+        menu()
+    else:
+        info_host = obtener_informacion_host(
+            incluir_ip_externa=not args.sin_ip_externa,
+            timeout_ip_externa=args.timeout_ip_externa,
+        )
+        mostrar_informacion(info_host, formato=args.formato)
+        if args.guardar is not None:
+            nombre_guardado = guardar_informacion_en_archivo(
+                info_host,
+                filename=args.guardar or None,
+                formato=args.formato,
+            )
+            print(f"Información guardada en {nombre_guardado}")


### PR DESCRIPTION
### Motivation
- Proveer una representación estructurada de la información de red para facilitar su consumo por otras herramientas.
- Añadir opciones para elegir formato de salida y guardar resultados a disco en texto o JSON.
- Ofrecer control sobre la consulta de IP externa y permitir un uso no interactivo vía CLI.

### Description
- Refactoriza la recolección en `obtener_informacion_host` para devolver un `dict` con hostname, IPs locales, IP externa opcional, interfaces y estadísticas de cada interfaz. 
- Añade `obtener_ip_externa` con timeout configurable y manejo de errores, y agrega anotaciones de tipos y uso de `datetime`.
- Implementa formateadores `formatear_informacion_texto`, `mostrar_informacion` y `guardar_informacion_en_archivo` que soportan salida en `text` y `json` y generan nombres de archivo con extensión automática.
- Incorpora `argparse` con opciones `--formato`, `--guardar`, `--sin-ip-externa`, `--timeout-ip-externa` y `--menu`, y amplía el menú interactivo para guardar en texto o JSON.

### Testing
- No se ejecutaron pruebas automatizadas sobre el código modificado.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698a25d7dfc8832eafa3ae7a443fb18d)